### PR TITLE
Update Django Lint

### DIFF
--- a/django/python-style-guide/.pylintrc
+++ b/django/python-style-guide/.pylintrc
@@ -230,11 +230,14 @@ method-rgx=(?x)^(?:(?P<exempt>_[a-z0-9_]+__|runTest|setUp|tearDown|setUpTestCase
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=(__.*__|main|test.*|.*test|.*Test)$
+no-docstring-rgx=(__.*__|main|test.*|.*test|.*Test|Meta)$
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
 docstring-min-length=10
+
+# Ignore unused arguments
+ignored-argument-names=args|kwargs|sender
 
 
 [TYPECHECK]
@@ -268,7 +271,7 @@ generated-members=
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=120
+max-line-length=140
 
 # TODO(https://github.com/PyCQA/pylint/issues/3352): Direct pylint to exempt
 # lines made too long by directives to pytype.

--- a/django/python-style-guide/README.md
+++ b/django/python-style-guide/README.md
@@ -6,7 +6,7 @@ We follow [Google style guide for Python](https://google.github.io/styleguide/py
 
 ## Linting
 
-* You can use `pylint` with this [.pylintrc](.pylintrc) to check if your code passed the standard.
+* You can use `pylint` with this [.pylintrc](https://raw.githubusercontent.com/C0D1UM/technical-standard/main/django/python-style-guide/.pylintrc) to check if your code passed the standard.
 
 ## Formatter
 


### PR DESCRIPTION
# Changes
## Lint rules

- No docstring for `Meta` class
- Ignore `args`, `kwargs`, `sender` (for signal) for checking unused arguments
- Increase max length from 120 to 140 characters

## Documentation
- Fix broken link of `.pylintrc`